### PR TITLE
Added new FAQ about deprecating Matrix, updated FAQs and contribute pages

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -1,6 +1,6 @@
 ---
 title: "About (FAQs)"
-date: 2020-11-04T21:00:00+00:00
+date: 2020-12-23T00:30:00+00:00
 draft: false
 menu: "main"
 ---
@@ -9,7 +9,7 @@ Glimpse Image Editor 0.2.0 is an open source image editing program based on the 
 
 Glimpse NX aims to create a lightweight new interface for pre-existing GNU Image Manipulation Program libraries and frameworks. We will provide more details about that project in coming months.
 
-The goal of both projects is to experiment with new ideas and expand the use of free/libre and open source software.
+The goal of both projects is to experiment with new ideas and expand the use of open source software.
 
 ### Introduction
 - [What is the correct name for your project?](#what-is-the-correct-name-for-your-project)
@@ -47,13 +47,14 @@ The goal of both projects is to experiment with new ideas and expand the use of 
 - [Where is the Glimpse code of conduct?](#where-is-the-glimpse-code-of-conduct)
 - [How does your project govern itself?](#how-does-this-project-govern-itself)
 - [What are all the Matrix channels for?](#what-are-all-the-matrix-channels-for)
+- [Why are you deprecating your Matrix channels?](#why-are-you-deprecating-your-matrix-channels)
 - [How do I stay up-to-date with this project?](#how-do-i-stay-up-to-date-with-this-project)
 - [How do I contribute to this project?](#how-do-i-contribute-to-this-project)
 
 ---
 
 ## What is the correct name for your project? {#what-is-the-correct-name-for-your-project}
-The open source software we produce is called "Glimpse Image Editor", but we sometimes shorten that to just "Glimpse". We refer to our governance structure, core contributors and participants on our public Matrix channel as "the Glimpse project". We often call our social media followers, donors and end users "the Glimpse Community".
+The open source software we produce is called "Glimpse Image Editor", but we sometimes shorten that to just "Glimpse". We refer to our governance structure, core contributors and participants on our Matrix channel and Discord server as "the Glimpse project". We often call our social media followers, donors and end users "the Glimpse Community".
 
 Glimpse NX is a separate project we plan to start soon where we will create a lightweight new interface for pre-existing GNU Image Manipulation Program libraries and frameworks. You may sometimes see it referred to as "the rewrite". We will provide more information about that project in coming weeks and months.
 
@@ -62,18 +63,18 @@ If you are a blogger or a member of the technology industry press, we do not yet
 [Return to top](#contents)
 
 ## What is Glimpse Image Editor? {#what-is-glimpse-image-editor}
-Glimpse Image Editor is a "fork" or "respin" of the [GNU Image Manipulation Program](https://www.gimp.org/), and it is also a free/libre and open source image editing application.
+Glimpse Image Editor is a "fork" or "respin" of the [GNU Image Manipulation Program](https://www.gimp.org/), and it is also an open source image editing application.
 
 This project was originally started due to long-standing disagreements between the GNU Image Manipulation Program developers and some of the software's users about who the target audience is, the priority of usability/accessibility changes, and whether it is still appropriate to call a 25 year old software program "the Gimp" as a joke.
 
 Forking (or "remixing") an existing software program is a long-established way to resolve such disputes. In fact, the [GNU manifesto](https://www.gnu.org/gnu/manifesto.en.html) encourages users to modify the applications they use to better suit their needs so long as they are also respectful to the community and make those changes available to others.
 
-While there was some controversy surrounding our project in the months after we first started it in July 2019, we believe that a long and independently-verifiable record of positive actions towards the GNU Image Manipulation Program developers and the wider free/libre and open source communities make our position and positive intentions clear.
+While there was some controversy surrounding our project in the months after we first started it in July 2019, we believe that a long and independently-verifiable record of positive actions towards the GNU Image Manipulation Program developers and the wider open source community make our position and positive intentions clear.
 
 [Return to top](#contents)
 
 ## What is Glimpse NX? {#what-is-glimpse-nx}
-Glimpse NX will be a free/libre software application using [GNOME](https://www.gnome.org/) technologies that provides a more lightweight and accessible user interface for the same underlying components that the GNU Image Manipulation Program uses. It will also be ported to Windows and MacOS.
+Glimpse NX will be an open source software application using [GNOME](https://www.gnome.org/) technologies that provides a more lightweight and accessible user interface for the same underlying components that the GNU Image Manipulation Program uses. It will also be ported to Windows and MacOS.
 
 We are still deciding which programming language to use, but [Rust](https://www.rust-lang.org/) is the most likely candidate. As we will be using components that are licensed under the [GNU LGPLv3](https://www.gnu.org/licenses/lgpl-3.0.html), we expect the project itself will be provided under the GNU General Public License v3 or a similar compatible license.
 
@@ -95,7 +96,7 @@ Our project also offers a more constructive path forward to people that have bec
 ## Are there any disabled people involved with the project? {#are-there-any-disabled-people-involved-with-the-project}
 Yes. However, our contributors are not under any obligation to disclose their status as a disabled person or the nature of their impairment(s) to you, as that is private medical information.
 
-We encourage free/libre and open source software developers **of all political stripes** to better prioritize fixing accessibility and usability problems, because seemingly small changes can make a big difference and it is not reasonable to constantly expect disabled people to fight you for them first.
+We encourage open source software developers **of all political stripes** to better prioritize fixing accessibility and usability problems, because seemingly small changes can make a big difference and it is not reasonable to constantly expect disabled people to fight you for them first.
 
 While there are many improvements we all need to make on the legacy systems we maintain, even limited efforts made in good faith can send a positive message that disabled people are welcome in our community and their needs matter to us.
 
@@ -130,7 +131,7 @@ We are aware of a number of other unrelated projects called "Glimpse". We have m
 
 The project's current stance is that while we are theoretically open to changing our name, there is very limited support in favor of actually doing so. We granted our critics time to find an alternative name that addresses the concerns they raised, fulfils our project's requirements and enjoys popular support. Even with three months and our assistance they were not able to do so, so we consider the matter closed for the time being.
 
-See ["How does your project govern itself?"](#how-does-this-project-govern-itself) for more details about why we now limit discussion about this topic on our Matrix channels.
+See ["How does your project govern itself?"](#how-does-this-project-govern-itself) for more details about why we now limit discussion about this topic on our Matrix channels and Discord server.
 
 [Return to top](#contents)
 
@@ -316,7 +317,7 @@ While we doubt we will convince everyone, we hope that our commitment to transpa
 ## Will you adopt a cryptocurrency or blockchain reward system? {#will-you-adopt-a-cryptocurrency-or-blockchain-reward-system}
 No, and we have no interest in our project being used as the experimental basis for such an initiative.
 
-If you would like to make the case for this idea, ensure you have read our [Matrix channel rules](https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right) and the [Code of Conduct](/code-of-conduct/) before proceeding. You should also read ["How does your project govern itself?"](#how-does-this-project-govern-itself) so you understand why our moderators may limit debate on some topics.
+Read ["How does your project govern itself?"](#how-does-this-project-govern-itself) for more information about why our moderators limit debate on some topics.
 
 [Return to top](#contents)
 
@@ -332,9 +333,11 @@ We know how important it is to enact the right code of conduct and enforce the r
 ## How does your project govern itself? {#how-does-this-project-govern-itself}
 The Glimpse Project is run by a self-appointed board called "the governance team", and it is currently made up of three members: [Bobby Moss](https://twitter.com/trechnex), [Christopher Davis](https://social.libre.fi/users/brainblasted), and [Luna](https://twitter.com/Clipsey5). Decisions are made with a majority vote after consultation with project contributors and any other interested parties.
 
-Most day-to-day discussion for the forked code happens in the **#glimpse:matrix.org** (or "Glimpse Community") Matrix channel. Anyone can join so long as they comply with our [code of conduct](/code-of-conduct/) and [follow the rules](https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right). This is where most of the decision-making happens, and our community has the opportunity to voice their opinions or share their domain-specific knowledge there.
+The **#glimpse:matrix.org** Matrix channel and the `#general` channel it is bridged to on our Discord server is where most of our decision-making happens, and our community has the opportunity to voice their opinions and share their domain-specific knowledge there.
 
-We also host a separate [Discord server](https://discord.gg/hZhRceq) for Glimpse NX development and technical support queries. The governance team also discusses project moderation decisions in a private channel on that server. You can read the rules for joining this server's public channels on the `#rules-and-info` channel.
+We host a [Discord server](https://discord.gg/hZhRceq) for project decisions, Glimpse NX development and some technical support queries. The governance team also discusses project moderation decisions in a private channel on that server. You can read the rules for joining this server's public channels on the `#rules-and-info` channel.
+
+Discussion for the forked code originally started in the **#glimpse:matrix.org** (or "Glimpse Development") Matrix channel. That channel is now invite-only and will eventually be deprecated, but channel members are still expected to comply with our [code of conduct](/code-of-conduct/) and [follow the rules](https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right).
 
 [Github Issues](https://github.com/glimpse-editor/Glimpse/issues) are used to track bug reports, suggestions and questions from the wider community, and items we have agreed as a project need action. Action items are allocated to a milestone to give an indication of their priority and likely timeline, but these are always provisional until the work is done.
 
@@ -345,12 +348,33 @@ Finally, the project may from time to time run polls on social media to canvas o
 [Return to top](#contents)
 
 ## What are all the Matrix channels for? {#what-are-all-the-matrix-channels-for}
-All of our channels are on matrix.org. You can get access to the invite-only channels by asking for it on the "Glimpse Community" channel.
+We currently maintain two invite-only channels on matrix.org, and both have been bridged to matching channels on [our Discord server](https://discord.gg/hZhRceq).
 
-- **#glimpse**: "Glimpse Community" channel that anyone can join so long as they [follow the rules](https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right) and comply with our [code of conduct](/code-of-conduct/)
+- **#glimpse**: "Glimpse Development" channel that anyone can request to join, and all members must [follow the rules](https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right) and comply with our [code of conduct](/code-of-conduct/)
 - **#glimpse-offtopic**: Off-topic chatter between well-known members of our community in a safe, welcoming environment.
 
-There is also a separate [Discord server](https://discord.gg/hZhRceq) for our project moderation channels and the technical support queries. You can read their rules by following the links on the `#rules-and-info` channel.
+The [Discord server](https://discord.gg/hZhRceq) was created for our project moderation channels and Glimpse NX development. You can read the rules on that server by following the links on the `#rules-and-info` channel.
+
+We encourage new contributors to join Discord as that is where most project activity now happens. We eventually plan to deprecate our Matrix channels.
+
+[Return to top](#contents)
+
+## Why are you deprecating your Matrix channels? {#why-are-you-deprecating-your-matrix-channels}
+
+As you will have read elsewhere on this FAQs page, there are two parallel development streams in the Glimpse project:
+
+- An open source fork of the GNU Image Manipulation Program 2.10.x called "Glimpse Image Editor"
+- A new open source image editing program for the GNOME desktop called "Glimpse NX"
+
+The eventual plan is to deprecate Glimpse Image Editor in favor of Glimpse NX. Matrix was the communication platform that was chosen by the fork's contributors, and Discord was chosen by the Glimpse NX contributors.
+
+Our Matrix channels are now both invite-only and have been bridged to our Discord server. We encourage new contributors join [our Discord server](https://discord.gg/hZhRceq) as that is where most project activity now happens.
+
+For reference, these are the core values we follow when we select our project tools and collaboration platforms:
+- We should aim to lower the barrier to entry for newcomers that have never contributed to an open source project before
+- We are open to trying any tools that our regular contributors suggest, and then using that experience to inform our decisions
+- We require comprehensive moderation tools that are not time-consuming to maintain, learn or use effectively
+- While open source solutions are preferred, our contributors' time and welfare are more important
 
 [Return to top](#contents)
 
@@ -359,7 +383,7 @@ You can follow us on [the fediverse](https://mastodon.art/@glimpse) and [Twitter
 
 Our [Open Collective](https://opencollective.com/glimpse) backers also get regular updates about the project. 
 
-Our Matrix and Discord channels are primarily intended for contributors and prospective contributors.
+Our Matrix and Discord channels are primarily intended for existing and prospective contributors. If you only want to keep up with project news, we encourage you to follow our social media accounts and RSS feed instead.
 
 [Return to top](#contents)
 

--- a/content/contribute.md
+++ b/content/contribute.md
@@ -1,6 +1,6 @@
 ---
 title: "Contribute"
-date: 2020-11-01T23:45:00+00:00
+date: 2020-12-23T00:45:00+00:00
 draft: false
 menu: "main"
 ---
@@ -25,7 +25,7 @@ The "rewrite" stream (also known as "Glimpse NX") aims to create a lightweight n
  * [Matrix](https://matrix.to/#/#glimpse:matrix.org)
  * [Discord](https://discord.gg/hZhRceq)
 
-  **Warning**: Before joining our public Matrix channel, we strongly encourage you to read [the rules you are expected to follow](https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right).
+**Note**: Our Matrix channels are now invite-only and will eventually be deprecated. [More information](/about/#why-are-you-deprecating-your-matrix-channels)
 
 ## News
  * [Facebook](https://fb.me/glimpse.editor)

--- a/data/index.yml
+++ b/data/index.yml
@@ -21,6 +21,6 @@ features:
     image: 'cytonn-photography-n95VMLxqM2I-unsplash.jpg'
     alt: 'A picture of two hands shaking in a gesture of friendship'
   - header: 'Planning For The Future'
-    summary: '"Glimpse NX" will provide a lightweight newcomer-friendly image editing experience with accessibility as its primary focus. We will provide more details about that exciting new free/libre software project as it develops.'
+    summary: '"Glimpse NX" will provide a lightweight newcomer-friendly image editing experience with accessibility as its primary focus. We will provide more details about that exciting new open source software project as it develops.'
     image: 'glimpse-nx-placeholder.jpg'
     alt: 'A placeholder Glimpse NX logo on a black background'

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -76,7 +76,7 @@
   <h2 id="contents">Contents</h2>
 <p>Glimpse Image Editor 0.2.0 is an open source image editing program based on the GNU Image Manipulation Program 2.10.18. You can read more about our development priorities and our target userbase here: <a href="https://github.com/glimpse-editor/Glimpse/wiki/Development-Priorities">https://github.com/glimpse-editor/Glimpse/wiki/Development-Priorities</a></p>
 <p>Glimpse NX aims to create a lightweight new interface for pre-existing GNU Image Manipulation Program libraries and frameworks. We will provide more details about that project in coming months.</p>
-<p>The goal of both projects is to experiment with new ideas and expand the use of free/libre and open source software.</p>
+<p>The goal of both projects is to experiment with new ideas and expand the use of open source software.</p>
 <h3 id="introduction">Introduction</h3>
 <ul>
 <li><a href="#what-is-the-correct-name-for-your-project">What is the correct name for your project?</a></li>
@@ -117,23 +117,24 @@
 <li><a href="#where-is-the-glimpse-code-of-conduct">Where is the Glimpse code of conduct?</a></li>
 <li><a href="#how-does-this-project-govern-itself">How does your project govern itself?</a></li>
 <li><a href="#what-are-all-the-matrix-channels-for">What are all the Matrix channels for?</a></li>
+<li><a href="#why-are-you-deprecating-your-matrix-channels">Why are you deprecating your Matrix channels?</a></li>
 <li><a href="#how-do-i-stay-up-to-date-with-this-project">How do I stay up-to-date with this project?</a></li>
 <li><a href="#how-do-i-contribute-to-this-project">How do I contribute to this project?</a></li>
 </ul>
 <hr>
 <h2 id="what-is-the-correct-name-for-your-project">What is the correct name for your project?</h2>
-<p>The open source software we produce is called &ldquo;Glimpse Image Editor&rdquo;, but we sometimes shorten that to just &ldquo;Glimpse&rdquo;. We refer to our governance structure, core contributors and participants on our public Matrix channel as &ldquo;the Glimpse project&rdquo;. We often call our social media followers, donors and end users &ldquo;the Glimpse Community&rdquo;.</p>
+<p>The open source software we produce is called &ldquo;Glimpse Image Editor&rdquo;, but we sometimes shorten that to just &ldquo;Glimpse&rdquo;. We refer to our governance structure, core contributors and participants on our Matrix channel and Discord server as &ldquo;the Glimpse project&rdquo;. We often call our social media followers, donors and end users &ldquo;the Glimpse Community&rdquo;.</p>
 <p>Glimpse NX is a separate project we plan to start soon where we will create a lightweight new interface for pre-existing GNU Image Manipulation Program libraries and frameworks. You may sometimes see it referred to as &ldquo;the rewrite&rdquo;. We will provide more information about that project in coming weeks and months.</p>
 <p>If you are a blogger or a member of the technology industry press, we do not yet have branding guidelines in place. However we have provided screenshots, our branding assets and instructions for their basic usage here: <a href="https://github.com/glimpse-editor/branding">https://github.com/glimpse-editor/branding</a>. You may also contact us directly <a href="mailto:glimpse.editor@icloud.com">by email</a> for further information about the project.</p>
 <p><a href="#contents">Return to top</a></p>
 <h2 id="what-is-glimpse-image-editor">What is Glimpse Image Editor?</h2>
-<p>Glimpse Image Editor is a &ldquo;fork&rdquo; or &ldquo;respin&rdquo; of the <a href="https://www.gimp.org/">GNU Image Manipulation Program</a>, and it is also a free/libre and open source image editing application.</p>
+<p>Glimpse Image Editor is a &ldquo;fork&rdquo; or &ldquo;respin&rdquo; of the <a href="https://www.gimp.org/">GNU Image Manipulation Program</a>, and it is also an open source image editing application.</p>
 <p>This project was originally started due to long-standing disagreements between the GNU Image Manipulation Program developers and some of the software&rsquo;s users about who the target audience is, the priority of usability/accessibility changes, and whether it is still appropriate to call a 25 year old software program &ldquo;the Gimp&rdquo; as a joke.</p>
 <p>Forking (or &ldquo;remixing&rdquo;) an existing software program is a long-established way to resolve such disputes. In fact, the <a href="https://www.gnu.org/gnu/manifesto.en.html">GNU manifesto</a> encourages users to modify the applications they use to better suit their needs so long as they are also respectful to the community and make those changes available to others.</p>
-<p>While there was some controversy surrounding our project in the months after we first started it in July 2019, we believe that a long and independently-verifiable record of positive actions towards the GNU Image Manipulation Program developers and the wider free/libre and open source communities make our position and positive intentions clear.</p>
+<p>While there was some controversy surrounding our project in the months after we first started it in July 2019, we believe that a long and independently-verifiable record of positive actions towards the GNU Image Manipulation Program developers and the wider open source community make our position and positive intentions clear.</p>
 <p><a href="#contents">Return to top</a></p>
 <h2 id="what-is-glimpse-nx">What is Glimpse NX?</h2>
-<p>Glimpse NX will be a free/libre software application using <a href="https://www.gnome.org/">GNOME</a> technologies that provides a more lightweight and accessible user interface for the same underlying components that the GNU Image Manipulation Program uses. It will also be ported to Windows and MacOS.</p>
+<p>Glimpse NX will be an open source software application using <a href="https://www.gnome.org/">GNOME</a> technologies that provides a more lightweight and accessible user interface for the same underlying components that the GNU Image Manipulation Program uses. It will also be ported to Windows and MacOS.</p>
 <p>We are still deciding which programming language to use, but <a href="https://www.rust-lang.org/">Rust</a> is the most likely candidate. As we will be using components that are licensed under the <a href="https://www.gnu.org/licenses/lgpl-3.0.html">GNU LGPLv3</a>, we expect the project itself will be provided under the GNU General Public License v3 or a similar compatible license.</p>
 <p>Further information for this exciting new spin-off project will be provided in coming months.</p>
 <p>As stated in previous blog posts, we did originally consider the possibility of creating a new bespoke cross-platform user interface toolkit and then writing an entirely new BSD-licensed program based on it with the more estoteric <a href="https://dlang.org/">D</a> programming language. A group of contributors investigated that solution, but after six months of incubation we collectively agreed that such an ambitious project cannot be delivered in a two year timeframe with the resources we have available.</p>
@@ -145,7 +146,7 @@
 <p><a href="#contents">Return to top</a></p>
 <h2 id="are-there-any-disabled-people-involved-with-the-project">Are there any disabled people involved with the project?</h2>
 <p>Yes. However, our contributors are not under any obligation to disclose their status as a disabled person or the nature of their impairment(s) to you, as that is private medical information.</p>
-<p>We encourage free/libre and open source software developers <strong>of all political stripes</strong> to better prioritize fixing accessibility and usability problems, because seemingly small changes can make a big difference and it is not reasonable to constantly expect disabled people to fight you for them first.</p>
+<p>We encourage open source software developers <strong>of all political stripes</strong> to better prioritize fixing accessibility and usability problems, because seemingly small changes can make a big difference and it is not reasonable to constantly expect disabled people to fight you for them first.</p>
 <p>While there are many improvements we all need to make on the legacy systems we maintain, even limited efforts made in good faith can send a positive message that disabled people are welcome in our community and their needs matter to us.</p>
 <p><a href="#contents">Return to top</a></p>
 <h2 id="do-you-intend-to-replace-the-gnu-image-manipulation-program">Do you intend to replace the GNU Image Manipulation Program?</h2>
@@ -164,7 +165,7 @@
 <h2 id="did-you-know-that-name-is-used-elsewhere">Did you know that name is used elsewhere?</h2>
 <p>We are aware of a number of other unrelated projects called &ldquo;Glimpse&rdquo;. We have made changes based on feedback from our critics such as changing our website&rsquo;s domain name and defining &ldquo;Glimpse&rdquo; as a shortened version of &ldquo;Glimpse Image Editor&rdquo;.</p>
 <p>The project&rsquo;s current stance is that while we are theoretically open to changing our name, there is very limited support in favor of actually doing so. We granted our critics time to find an alternative name that addresses the concerns they raised, fulfils our project&rsquo;s requirements and enjoys popular support. Even with three months and our assistance they were not able to do so, so we consider the matter closed for the time being.</p>
-<p>See <a href="#how-does-this-project-govern-itself">&ldquo;How does your project govern itself?&quot;</a> for more details about why we now limit discussion about this topic on our Matrix channels.</p>
+<p>See <a href="#how-does-this-project-govern-itself">&ldquo;How does your project govern itself?&quot;</a> for more details about why we now limit discussion about this topic on our Matrix channels and Discord server.</p>
 <p><a href="#contents">Return to top</a></p>
 <h2 id="what-if-i-find-the-word-glimpse-offensive">What if I find the word &ldquo;Glimpse&rdquo; offensive?</h2>
 <p>That seems unlikely given we checked its meaning in every known language, but if you have a legitimate concern then let us know.</p>
@@ -266,7 +267,7 @@
 <p><a href="#contents">Return to top</a></p>
 <h2 id="will-you-adopt-a-cryptocurrency-or-blockchain-reward-system">Will you adopt a cryptocurrency or blockchain reward system?</h2>
 <p>No, and we have no interest in our project being used as the experimental basis for such an initiative.</p>
-<p>If you would like to make the case for this idea, ensure you have read our <a href="https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right">Matrix channel rules</a> and the <a href="/code-of-conduct/">Code of Conduct</a> before proceeding. You should also read <a href="#how-does-this-project-govern-itself">&ldquo;How does your project govern itself?&quot;</a> so you understand why our moderators may limit debate on some topics.</p>
+<p>Read <a href="#how-does-this-project-govern-itself">&ldquo;How does your project govern itself?&quot;</a> for more information about why our moderators limit debate on some topics.</p>
 <p><a href="#contents">Return to top</a></p>
 <h2 id="where-is-the-glimpse-code-of-conduct">Where is the Glimpse code of conduct?</h2>
 <p>You will find it on <a href="/code-of-conduct/">this page</a>. Our code of conduct is based on <a href="https://www.contributor-covenant.org/">the contributor covenant</a> and will be developed and amended over time as the need arises. As this project spawned from <a href="https://joinmastodon.org/">the fediverse</a> our experiences in that online space inform the project&rsquo;s future governance and direction.</p>
@@ -275,24 +276,42 @@
 <p><a href="#contents">Return to top</a></p>
 <h2 id="how-does-this-project-govern-itself">How does your project govern itself?</h2>
 <p>The Glimpse Project is run by a self-appointed board called &ldquo;the governance team&rdquo;, and it is currently made up of three members: <a href="https://twitter.com/trechnex">Bobby Moss</a>, <a href="https://social.libre.fi/users/brainblasted">Christopher Davis</a>, and <a href="https://twitter.com/Clipsey5">Luna</a>. Decisions are made with a majority vote after consultation with project contributors and any other interested parties.</p>
-<p>Most day-to-day discussion for the forked code happens in the <strong>#glimpse:matrix.org</strong> (or &ldquo;Glimpse Community&rdquo;) Matrix channel. Anyone can join so long as they comply with our <a href="/code-of-conduct/">code of conduct</a> and <a href="https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right">follow the rules</a>. This is where most of the decision-making happens, and our community has the opportunity to voice their opinions or share their domain-specific knowledge there.</p>
-<p>We also host a separate <a href="https://discord.gg/hZhRceq">Discord server</a> for Glimpse NX development and technical support queries. The governance team also discusses project moderation decisions in a private channel on that server. You can read the rules for joining this server&rsquo;s public channels on the <code>#rules-and-info</code> channel.</p>
+<p>The <strong>#glimpse:matrix.org</strong> Matrix channel and the <code>#general</code> channel it is bridged to on our Discord server is where most of our decision-making happens, and our community has the opportunity to voice their opinions and share their domain-specific knowledge there.</p>
+<p>We host a <a href="https://discord.gg/hZhRceq">Discord server</a> for project decisions, Glimpse NX development and some technical support queries. The governance team also discusses project moderation decisions in a private channel on that server. You can read the rules for joining this server&rsquo;s public channels on the <code>#rules-and-info</code> channel.</p>
+<p>Discussion for the forked code originally started in the <strong>#glimpse:matrix.org</strong> (or &ldquo;Glimpse Development&rdquo;) Matrix channel. That channel is now invite-only and will eventually be deprecated, but channel members are still expected to comply with our <a href="/code-of-conduct/">code of conduct</a> and <a href="https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right">follow the rules</a>.</p>
 <p><a href="https://github.com/glimpse-editor/Glimpse/issues">Github Issues</a> are used to track bug reports, suggestions and questions from the wider community, and items we have agreed as a project need action. Action items are allocated to a milestone to give an indication of their priority and likely timeline, but these are always provisional until the work is done.</p>
 <p>No decision is ever set in stone and can be revisited if new information comes to light or there is enough support within the project to do so. The governance team will generally only block the re-opening of an issue or delay a decision if the discussion is becoming too heated or obstructs the day-to-day running of the project. The governance team also reserves the right to end a discussion if, after giving an idea a fair hearing, there is clearly a lack of support within the Glimpse project in favor of it being worked on or developed any further.</p>
 <p>Finally, the project may from time to time run polls on social media to canvas opinion for specific issues if there is support for doing so. They are always non-binding and only intended to facilitate the existing decision-making process.</p>
 <p><a href="#contents">Return to top</a></p>
 <h2 id="what-are-all-the-matrix-channels-for">What are all the Matrix channels for?</h2>
-<p>All of our channels are on matrix.org. You can get access to the invite-only channels by asking for it on the &ldquo;Glimpse Community&rdquo; channel.</p>
+<p>We currently maintain two invite-only channels on matrix.org, and both have been bridged to matching channels on <a href="https://discord.gg/hZhRceq">our Discord server</a>.</p>
 <ul>
-<li><strong>#glimpse</strong>: &ldquo;Glimpse Community&rdquo; channel that anyone can join so long as they <a href="https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right">follow the rules</a> and comply with our <a href="/code-of-conduct/">code of conduct</a></li>
+<li><strong>#glimpse</strong>: &ldquo;Glimpse Development&rdquo; channel that anyone can request to join, and all members must <a href="https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right">follow the rules</a> and comply with our <a href="/code-of-conduct/">code of conduct</a></li>
 <li><strong>#glimpse-offtopic</strong>: Off-topic chatter between well-known members of our community in a safe, welcoming environment.</li>
 </ul>
-<p>There is also a separate <a href="https://discord.gg/hZhRceq">Discord server</a> for our project moderation channels and the technical support queries. You can read their rules by following the links on the <code>#rules-and-info</code> channel.</p>
+<p>The <a href="https://discord.gg/hZhRceq">Discord server</a> was created for our project moderation channels and Glimpse NX development. You can read the rules on that server by following the links on the <code>#rules-and-info</code> channel.</p>
+<p>We encourage new contributors to join Discord as that is where most project activity now happens. We eventually plan to deprecate our Matrix channels.</p>
+<p><a href="#contents">Return to top</a></p>
+<h2 id="why-are-you-deprecating-your-matrix-channels">Why are you deprecating your Matrix channels?</h2>
+<p>As you will have read elsewhere on this FAQs page, there are two parallel development streams in the Glimpse project:</p>
+<ul>
+<li>An open source fork of the GNU Image Manipulation Program 2.10.x called &ldquo;Glimpse Image Editor&rdquo;</li>
+<li>A new open source image editing program for the GNOME desktop called &ldquo;Glimpse NX&rdquo;</li>
+</ul>
+<p>The eventual plan is to deprecate Glimpse Image Editor in favor of Glimpse NX. Matrix was the communication platform that was chosen by the fork&rsquo;s contributors, and Discord was chosen by the Glimpse NX contributors.</p>
+<p>Our Matrix channels are now both invite-only and have been bridged to our Discord server. We encourage new contributors join <a href="https://discord.gg/hZhRceq">our Discord server</a> as that is where most project activity now happens.</p>
+<p>For reference, these are the core values we follow when we select our project tools and collaboration platforms:</p>
+<ul>
+<li>We should aim to lower the barrier to entry for newcomers that have never contributed to an open source project before</li>
+<li>We are open to trying any tools that our regular contributors suggest, and then using that experience to inform our decisions</li>
+<li>We require comprehensive moderation tools that are not time-consuming to maintain, learn or use effectively</li>
+<li>While open source solutions are preferred, our contributors&rsquo; time and welfare are more important</li>
+</ul>
 <p><a href="#contents">Return to top</a></p>
 <h2 id="how-do-i-stay-up-to-date-with-this-project">How do I stay up-to-date with this project?</h2>
 <p>You can follow us on <a href="https://mastodon.art/@glimpse">the fediverse</a> and <a href="https://twitter.com/glimpse_editor">Twitter</a>. This blog also has a full text <a href="https://getglimpse.app/index.xml">RSS feed</a>. We also recently setup a <a href="fb.me/glimpse.editor">Facebook page</a>.</p>
 <p>Our <a href="https://opencollective.com/glimpse">Open Collective</a> backers also get regular updates about the project.</p>
-<p>Our Matrix and Discord channels are primarily intended for contributors and prospective contributors.</p>
+<p>Our Matrix and Discord channels are primarily intended for existing and prospective contributors. If you only want to keep up with project news, we encourage you to follow our social media accounts and RSS feed instead.</p>
 <p><a href="#contents">Return to top</a></p>
 <h2 id="how-do-i-contribute-to-this-project">How do I contribute to this project?</h2>
 <p>All of our contribution links are available on our <a href="/contribute/">Contribute</a> page.</p>

--- a/docs/contribute/index.html
+++ b/docs/contribute/index.html
@@ -93,7 +93,7 @@
 <li><a href="https://matrix.to/#/#glimpse:matrix.org">Matrix</a></li>
 <li><a href="https://discord.gg/hZhRceq">Discord</a></li>
 </ul>
-<p><strong>Warning</strong>: Before joining our public Matrix channel, we strongly encourage you to read <a href="https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right">the rules you are expected to follow</a>.</p>
+<p><strong>Note</strong>: Our Matrix channels are now invite-only and will eventually be deprecated. <a href="/about/#why-are-you-deprecating-your-matrix-channels">More information</a></p>
 <h2 id="news">News</h2>
 <ul>
 <li><a href="https://fb.me/glimpse.editor">Facebook</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -155,7 +155,7 @@
               <div class="row my-5 align-items-center">
                     <div class="col-md">
                         <h3>Planning For The Future</h4>
-                        <p class="text-muted">&#34;Glimpse NX&#34; will provide a lightweight newcomer-friendly image editing experience with accessibility as its primary focus. We will provide more details about that exciting new free/libre software project as it develops.</p>
+                        <p class="text-muted">&#34;Glimpse NX&#34; will provide a lightweight newcomer-friendly image editing experience with accessibility as its primary focus. We will provide more details about that exciting new open source software project as it develops.</p>
                     </div>
                     <div class="dots-background col-md order-last order-md-first">
                         <img class="border img-fluid rounded" src="/glimpse-nx-placeholder.jpg" alt="A placeholder Glimpse NX logo on a black background"> 

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -12,24 +12,66 @@
     
     
     <item>
-      <title>Posts</title>
-      <link>https://glimpse-editor.org/posts/</link>
-      <pubDate>Sat, 21 Nov 2020 23:25:00 +0000</pubDate>
+      <title>Contribute</title>
+      <link>https://glimpse-editor.org/contribute/</link>
+      <pubDate>Wed, 23 Dec 2020 00:45:00 +0000</pubDate>
       
-      <guid>https://glimpse-editor.org/posts/</guid>
-      <description></description>
+      <guid>https://glimpse-editor.org/contribute/</guid>
+      <description>&lt;p&gt;Please note that we are developing Glimpse Image Editor in two parallel streams.&lt;/p&gt;
+&lt;p&gt;The &amp;ldquo;fork&amp;rdquo; stream is already providing a workable solution for people who dislike the &amp;ldquo;gimp&amp;rdquo; name or encounter barriers when they advocate the GNU Image Manipulation Program in schools, universities and workplaces. You can read more about our development priorities and our target userbase here: &lt;a href=&#34;https://github.com/glimpse-editor/Glimpse/wiki/Development-Priorities&#34;&gt;https://github.com/glimpse-editor/Glimpse/wiki/Development-Priorities&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;The &amp;ldquo;rewrite&amp;rdquo; stream (also known as &amp;ldquo;Glimpse NX&amp;rdquo;) aims to create a lightweight new interface for pre-existing GNU Image Manipulation Program libraries and frameworks. We will provide more details about that project in coming months.&lt;/p&gt;
+&lt;h2 id=&#34;code-bug-reports-etc-for-glimpse-image-editor&#34;&gt;Code, Bug Reports, etc for Glimpse Image Editor&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href=&#34;https://github.com/glimpse-editor/Glimpse/issues&#34;&gt;Bug Reports&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&#34;https://github.com/glimpse-editor/Glimpse/milestones&#34;&gt;Development Road Map&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&#34;https://github.com/glimpse-editor/Glimpse&#34;&gt;Source Code&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;You can also submit bug reports and feature requests &lt;a href=&#34;mailto:glimpse-editor@fire.fundersclub.com&#34;&gt;via email&lt;/a&gt;.&lt;/p&gt;
+&lt;h2 id=&#34;art-mockups-etc&#34;&gt;Art, mockups, etc.&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href=&#34;https://github.com/glimpse-editor/branding&#34;&gt;Branding&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&#34;https://wiki.glimpse-editor.org/&#34;&gt;Wiki&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;h2 id=&#34;discussion-and-technical-support&#34;&gt;Discussion and Technical Support&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href=&#34;https://matrix.to/#/#glimpse:matrix.org&#34;&gt;Matrix&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&#34;https://discord.gg/hZhRceq&#34;&gt;Discord&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;&lt;strong&gt;Note&lt;/strong&gt;: Our Matrix channels are now invite-only and will eventually be deprecated. &lt;a href=&#34;https://glimpse-editor.org/about/#why-are-you-deprecating-your-matrix-channels&#34;&gt;More information&lt;/a&gt;&lt;/p&gt;
+&lt;h2 id=&#34;news&#34;&gt;News&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href=&#34;https://fb.me/glimpse.editor&#34;&gt;Facebook&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&#34;https://mastodon.art/@glimpse&#34;&gt;Mastodon&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&#34;../posts/index.xml&#34;&gt;RSS&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&#34;https://twitter.com/glimpse_editor&#34;&gt;Twitter&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;h2 id=&#34;donate&#34;&gt;Donate&lt;/h2&gt;
+&lt;p&gt;To help cover our project&amp;rsquo;s costs and enable us to plan for future spending, please donate via these links:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href=&#34;https://github.com/sponsors/glimpse-editor&#34;&gt;Github Sponsors&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&#34;https://opencollective.com/glimpse&#34;&gt;Open Collective&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;If you can afford to do so we recommend donating to &lt;a href=&#34;https://www.gimp.org/donating/&#34;&gt;GNU Image Manipulation Program&lt;/a&gt;, the upstream project on which our fork relies. We periodically &lt;a href=&#34;https://opencollective.com/glimpse/expenses?tag=donation&#34;&gt;pass along a portion of our donations&lt;/a&gt; to them as our way of thanking them for the amazing work they do.&lt;/p&gt;
+&lt;h2 id=&#34;mediapress-contact&#34;&gt;Media/Press Contact&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href=&#34;mailto:glimpse.editor@icloud.com&#34;&gt;Email&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;h2 id=&#34;community-supported-channels&#34;&gt;Community Supported Channels&lt;/h2&gt;
+&lt;p&gt;We welcome members of our community starting their own unofficial support forums and communication channels.
+Please note that we do not monitor or moderate those platforms, and cannot guarantee they are a safe and welcoming environment for everyone. &lt;strong&gt;If you choose to use them, you do so at your own risk.&lt;/strong&gt;&lt;/p&gt;
+</description>
     </item>
     
     <item>
       <title>About (FAQs)</title>
       <link>https://glimpse-editor.org/about/</link>
-      <pubDate>Wed, 04 Nov 2020 21:00:00 +0000</pubDate>
+      <pubDate>Wed, 23 Dec 2020 00:30:00 +0000</pubDate>
       
       <guid>https://glimpse-editor.org/about/</guid>
       <description>&lt;h2 id=&#34;contents&#34;&gt;Contents&lt;/h2&gt;
 &lt;p&gt;Glimpse Image Editor 0.2.0 is an open source image editing program based on the GNU Image Manipulation Program 2.10.18. You can read more about our development priorities and our target userbase here: &lt;a href=&#34;https://github.com/glimpse-editor/Glimpse/wiki/Development-Priorities&#34;&gt;https://github.com/glimpse-editor/Glimpse/wiki/Development-Priorities&lt;/a&gt;&lt;/p&gt;
 &lt;p&gt;Glimpse NX aims to create a lightweight new interface for pre-existing GNU Image Manipulation Program libraries and frameworks. We will provide more details about that project in coming months.&lt;/p&gt;
-&lt;p&gt;The goal of both projects is to experiment with new ideas and expand the use of free/libre and open source software.&lt;/p&gt;
+&lt;p&gt;The goal of both projects is to experiment with new ideas and expand the use of open source software.&lt;/p&gt;
 &lt;h3 id=&#34;introduction&#34;&gt;Introduction&lt;/h3&gt;
 &lt;ul&gt;
 &lt;li&gt;&lt;a href=&#34;#what-is-the-correct-name-for-your-project&#34;&gt;What is the correct name for your project?&lt;/a&gt;&lt;/li&gt;
@@ -70,23 +112,24 @@
 &lt;li&gt;&lt;a href=&#34;#where-is-the-glimpse-code-of-conduct&#34;&gt;Where is the Glimpse code of conduct?&lt;/a&gt;&lt;/li&gt;
 &lt;li&gt;&lt;a href=&#34;#how-does-this-project-govern-itself&#34;&gt;How does your project govern itself?&lt;/a&gt;&lt;/li&gt;
 &lt;li&gt;&lt;a href=&#34;#what-are-all-the-matrix-channels-for&#34;&gt;What are all the Matrix channels for?&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&#34;#why-are-you-deprecating-your-matrix-channels&#34;&gt;Why are you deprecating your Matrix channels?&lt;/a&gt;&lt;/li&gt;
 &lt;li&gt;&lt;a href=&#34;#how-do-i-stay-up-to-date-with-this-project&#34;&gt;How do I stay up-to-date with this project?&lt;/a&gt;&lt;/li&gt;
 &lt;li&gt;&lt;a href=&#34;#how-do-i-contribute-to-this-project&#34;&gt;How do I contribute to this project?&lt;/a&gt;&lt;/li&gt;
 &lt;/ul&gt;
 &lt;hr&gt;
 &lt;h2 id=&#34;what-is-the-correct-name-for-your-project&#34;&gt;What is the correct name for your project?&lt;/h2&gt;
-&lt;p&gt;The open source software we produce is called &amp;ldquo;Glimpse Image Editor&amp;rdquo;, but we sometimes shorten that to just &amp;ldquo;Glimpse&amp;rdquo;. We refer to our governance structure, core contributors and participants on our public Matrix channel as &amp;ldquo;the Glimpse project&amp;rdquo;. We often call our social media followers, donors and end users &amp;ldquo;the Glimpse Community&amp;rdquo;.&lt;/p&gt;
+&lt;p&gt;The open source software we produce is called &amp;ldquo;Glimpse Image Editor&amp;rdquo;, but we sometimes shorten that to just &amp;ldquo;Glimpse&amp;rdquo;. We refer to our governance structure, core contributors and participants on our Matrix channel and Discord server as &amp;ldquo;the Glimpse project&amp;rdquo;. We often call our social media followers, donors and end users &amp;ldquo;the Glimpse Community&amp;rdquo;.&lt;/p&gt;
 &lt;p&gt;Glimpse NX is a separate project we plan to start soon where we will create a lightweight new interface for pre-existing GNU Image Manipulation Program libraries and frameworks. You may sometimes see it referred to as &amp;ldquo;the rewrite&amp;rdquo;. We will provide more information about that project in coming weeks and months.&lt;/p&gt;
 &lt;p&gt;If you are a blogger or a member of the technology industry press, we do not yet have branding guidelines in place. However we have provided screenshots, our branding assets and instructions for their basic usage here: &lt;a href=&#34;https://github.com/glimpse-editor/branding&#34;&gt;https://github.com/glimpse-editor/branding&lt;/a&gt;. You may also contact us directly &lt;a href=&#34;mailto:glimpse.editor@icloud.com&#34;&gt;by email&lt;/a&gt; for further information about the project.&lt;/p&gt;
 &lt;p&gt;&lt;a href=&#34;#contents&#34;&gt;Return to top&lt;/a&gt;&lt;/p&gt;
 &lt;h2 id=&#34;what-is-glimpse-image-editor&#34;&gt;What is Glimpse Image Editor?&lt;/h2&gt;
-&lt;p&gt;Glimpse Image Editor is a &amp;ldquo;fork&amp;rdquo; or &amp;ldquo;respin&amp;rdquo; of the &lt;a href=&#34;https://www.gimp.org/&#34;&gt;GNU Image Manipulation Program&lt;/a&gt;, and it is also a free/libre and open source image editing application.&lt;/p&gt;
+&lt;p&gt;Glimpse Image Editor is a &amp;ldquo;fork&amp;rdquo; or &amp;ldquo;respin&amp;rdquo; of the &lt;a href=&#34;https://www.gimp.org/&#34;&gt;GNU Image Manipulation Program&lt;/a&gt;, and it is also an open source image editing application.&lt;/p&gt;
 &lt;p&gt;This project was originally started due to long-standing disagreements between the GNU Image Manipulation Program developers and some of the software&amp;rsquo;s users about who the target audience is, the priority of usability/accessibility changes, and whether it is still appropriate to call a 25 year old software program &amp;ldquo;the Gimp&amp;rdquo; as a joke.&lt;/p&gt;
 &lt;p&gt;Forking (or &amp;ldquo;remixing&amp;rdquo;) an existing software program is a long-established way to resolve such disputes. In fact, the &lt;a href=&#34;https://www.gnu.org/gnu/manifesto.en.html&#34;&gt;GNU manifesto&lt;/a&gt; encourages users to modify the applications they use to better suit their needs so long as they are also respectful to the community and make those changes available to others.&lt;/p&gt;
-&lt;p&gt;While there was some controversy surrounding our project in the months after we first started it in July 2019, we believe that a long and independently-verifiable record of positive actions towards the GNU Image Manipulation Program developers and the wider free/libre and open source communities make our position and positive intentions clear.&lt;/p&gt;
+&lt;p&gt;While there was some controversy surrounding our project in the months after we first started it in July 2019, we believe that a long and independently-verifiable record of positive actions towards the GNU Image Manipulation Program developers and the wider open source community make our position and positive intentions clear.&lt;/p&gt;
 &lt;p&gt;&lt;a href=&#34;#contents&#34;&gt;Return to top&lt;/a&gt;&lt;/p&gt;
 &lt;h2 id=&#34;what-is-glimpse-nx&#34;&gt;What is Glimpse NX?&lt;/h2&gt;
-&lt;p&gt;Glimpse NX will be a free/libre software application using &lt;a href=&#34;https://www.gnome.org/&#34;&gt;GNOME&lt;/a&gt; technologies that provides a more lightweight and accessible user interface for the same underlying components that the GNU Image Manipulation Program uses. It will also be ported to Windows and MacOS.&lt;/p&gt;
+&lt;p&gt;Glimpse NX will be an open source software application using &lt;a href=&#34;https://www.gnome.org/&#34;&gt;GNOME&lt;/a&gt; technologies that provides a more lightweight and accessible user interface for the same underlying components that the GNU Image Manipulation Program uses. It will also be ported to Windows and MacOS.&lt;/p&gt;
 &lt;p&gt;We are still deciding which programming language to use, but &lt;a href=&#34;https://www.rust-lang.org/&#34;&gt;Rust&lt;/a&gt; is the most likely candidate. As we will be using components that are licensed under the &lt;a href=&#34;https://www.gnu.org/licenses/lgpl-3.0.html&#34;&gt;GNU LGPLv3&lt;/a&gt;, we expect the project itself will be provided under the GNU General Public License v3 or a similar compatible license.&lt;/p&gt;
 &lt;p&gt;Further information for this exciting new spin-off project will be provided in coming months.&lt;/p&gt;
 &lt;p&gt;As stated in previous blog posts, we did originally consider the possibility of creating a new bespoke cross-platform user interface toolkit and then writing an entirely new BSD-licensed program based on it with the more estoteric &lt;a href=&#34;https://dlang.org/&#34;&gt;D&lt;/a&gt; programming language. A group of contributors investigated that solution, but after six months of incubation we collectively agreed that such an ambitious project cannot be delivered in a two year timeframe with the resources we have available.&lt;/p&gt;
@@ -98,7 +141,7 @@
 &lt;p&gt;&lt;a href=&#34;#contents&#34;&gt;Return to top&lt;/a&gt;&lt;/p&gt;
 &lt;h2 id=&#34;are-there-any-disabled-people-involved-with-the-project&#34;&gt;Are there any disabled people involved with the project?&lt;/h2&gt;
 &lt;p&gt;Yes. However, our contributors are not under any obligation to disclose their status as a disabled person or the nature of their impairment(s) to you, as that is private medical information.&lt;/p&gt;
-&lt;p&gt;We encourage free/libre and open source software developers &lt;strong&gt;of all political stripes&lt;/strong&gt; to better prioritize fixing accessibility and usability problems, because seemingly small changes can make a big difference and it is not reasonable to constantly expect disabled people to fight you for them first.&lt;/p&gt;
+&lt;p&gt;We encourage open source software developers &lt;strong&gt;of all political stripes&lt;/strong&gt; to better prioritize fixing accessibility and usability problems, because seemingly small changes can make a big difference and it is not reasonable to constantly expect disabled people to fight you for them first.&lt;/p&gt;
 &lt;p&gt;While there are many improvements we all need to make on the legacy systems we maintain, even limited efforts made in good faith can send a positive message that disabled people are welcome in our community and their needs matter to us.&lt;/p&gt;
 &lt;p&gt;&lt;a href=&#34;#contents&#34;&gt;Return to top&lt;/a&gt;&lt;/p&gt;
 &lt;h2 id=&#34;do-you-intend-to-replace-the-gnu-image-manipulation-program&#34;&gt;Do you intend to replace the GNU Image Manipulation Program?&lt;/h2&gt;
@@ -117,7 +160,7 @@
 &lt;h2 id=&#34;did-you-know-that-name-is-used-elsewhere&#34;&gt;Did you know that name is used elsewhere?&lt;/h2&gt;
 &lt;p&gt;We are aware of a number of other unrelated projects called &amp;ldquo;Glimpse&amp;rdquo;. We have made changes based on feedback from our critics such as changing our website&amp;rsquo;s domain name and defining &amp;ldquo;Glimpse&amp;rdquo; as a shortened version of &amp;ldquo;Glimpse Image Editor&amp;rdquo;.&lt;/p&gt;
 &lt;p&gt;The project&amp;rsquo;s current stance is that while we are theoretically open to changing our name, there is very limited support in favor of actually doing so. We granted our critics time to find an alternative name that addresses the concerns they raised, fulfils our project&amp;rsquo;s requirements and enjoys popular support. Even with three months and our assistance they were not able to do so, so we consider the matter closed for the time being.&lt;/p&gt;
-&lt;p&gt;See &lt;a href=&#34;#how-does-this-project-govern-itself&#34;&gt;&amp;ldquo;How does your project govern itself?&amp;quot;&lt;/a&gt; for more details about why we now limit discussion about this topic on our Matrix channels.&lt;/p&gt;
+&lt;p&gt;See &lt;a href=&#34;#how-does-this-project-govern-itself&#34;&gt;&amp;ldquo;How does your project govern itself?&amp;quot;&lt;/a&gt; for more details about why we now limit discussion about this topic on our Matrix channels and Discord server.&lt;/p&gt;
 &lt;p&gt;&lt;a href=&#34;#contents&#34;&gt;Return to top&lt;/a&gt;&lt;/p&gt;
 &lt;h2 id=&#34;what-if-i-find-the-word-glimpse-offensive&#34;&gt;What if I find the word &amp;ldquo;Glimpse&amp;rdquo; offensive?&lt;/h2&gt;
 &lt;p&gt;That seems unlikely given we checked its meaning in every known language, but if you have a legitimate concern then let us know.&lt;/p&gt;
@@ -219,7 +262,7 @@
 &lt;p&gt;&lt;a href=&#34;#contents&#34;&gt;Return to top&lt;/a&gt;&lt;/p&gt;
 &lt;h2 id=&#34;will-you-adopt-a-cryptocurrency-or-blockchain-reward-system&#34;&gt;Will you adopt a cryptocurrency or blockchain reward system?&lt;/h2&gt;
 &lt;p&gt;No, and we have no interest in our project being used as the experimental basis for such an initiative.&lt;/p&gt;
-&lt;p&gt;If you would like to make the case for this idea, ensure you have read our &lt;a href=&#34;https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right&#34;&gt;Matrix channel rules&lt;/a&gt; and the &lt;a href=&#34;https://glimpse-editor.org/code-of-conduct/&#34;&gt;Code of Conduct&lt;/a&gt; before proceeding. You should also read &lt;a href=&#34;#how-does-this-project-govern-itself&#34;&gt;&amp;ldquo;How does your project govern itself?&amp;quot;&lt;/a&gt; so you understand why our moderators may limit debate on some topics.&lt;/p&gt;
+&lt;p&gt;Read &lt;a href=&#34;#how-does-this-project-govern-itself&#34;&gt;&amp;ldquo;How does your project govern itself?&amp;quot;&lt;/a&gt; for more information about why our moderators limit debate on some topics.&lt;/p&gt;
 &lt;p&gt;&lt;a href=&#34;#contents&#34;&gt;Return to top&lt;/a&gt;&lt;/p&gt;
 &lt;h2 id=&#34;where-is-the-glimpse-code-of-conduct&#34;&gt;Where is the Glimpse code of conduct?&lt;/h2&gt;
 &lt;p&gt;You will find it on &lt;a href=&#34;https://glimpse-editor.org/code-of-conduct/&#34;&gt;this page&lt;/a&gt;. Our code of conduct is based on &lt;a href=&#34;https://www.contributor-covenant.org/&#34;&gt;the contributor covenant&lt;/a&gt; and will be developed and amended over time as the need arises. As this project spawned from &lt;a href=&#34;https://joinmastodon.org/&#34;&gt;the fediverse&lt;/a&gt; our experiences in that online space inform the project&amp;rsquo;s future governance and direction.&lt;/p&gt;
@@ -228,24 +271,42 @@
 &lt;p&gt;&lt;a href=&#34;#contents&#34;&gt;Return to top&lt;/a&gt;&lt;/p&gt;
 &lt;h2 id=&#34;how-does-this-project-govern-itself&#34;&gt;How does your project govern itself?&lt;/h2&gt;
 &lt;p&gt;The Glimpse Project is run by a self-appointed board called &amp;ldquo;the governance team&amp;rdquo;, and it is currently made up of three members: &lt;a href=&#34;https://twitter.com/trechnex&#34;&gt;Bobby Moss&lt;/a&gt;, &lt;a href=&#34;https://social.libre.fi/users/brainblasted&#34;&gt;Christopher Davis&lt;/a&gt;, and &lt;a href=&#34;https://twitter.com/Clipsey5&#34;&gt;Luna&lt;/a&gt;. Decisions are made with a majority vote after consultation with project contributors and any other interested parties.&lt;/p&gt;
-&lt;p&gt;Most day-to-day discussion for the forked code happens in the &lt;strong&gt;#glimpse:matrix.org&lt;/strong&gt; (or &amp;ldquo;Glimpse Community&amp;rdquo;) Matrix channel. Anyone can join so long as they comply with our &lt;a href=&#34;https://glimpse-editor.org/code-of-conduct/&#34;&gt;code of conduct&lt;/a&gt; and &lt;a href=&#34;https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right&#34;&gt;follow the rules&lt;/a&gt;. This is where most of the decision-making happens, and our community has the opportunity to voice their opinions or share their domain-specific knowledge there.&lt;/p&gt;
-&lt;p&gt;We also host a separate &lt;a href=&#34;https://discord.gg/hZhRceq&#34;&gt;Discord server&lt;/a&gt; for Glimpse NX development and technical support queries. The governance team also discusses project moderation decisions in a private channel on that server. You can read the rules for joining this server&amp;rsquo;s public channels on the &lt;code&gt;#rules-and-info&lt;/code&gt; channel.&lt;/p&gt;
+&lt;p&gt;The &lt;strong&gt;#glimpse:matrix.org&lt;/strong&gt; Matrix channel and the &lt;code&gt;#general&lt;/code&gt; channel it is bridged to on our Discord server is where most of our decision-making happens, and our community has the opportunity to voice their opinions and share their domain-specific knowledge there.&lt;/p&gt;
+&lt;p&gt;We host a &lt;a href=&#34;https://discord.gg/hZhRceq&#34;&gt;Discord server&lt;/a&gt; for project decisions, Glimpse NX development and some technical support queries. The governance team also discusses project moderation decisions in a private channel on that server. You can read the rules for joining this server&amp;rsquo;s public channels on the &lt;code&gt;#rules-and-info&lt;/code&gt; channel.&lt;/p&gt;
+&lt;p&gt;Discussion for the forked code originally started in the &lt;strong&gt;#glimpse:matrix.org&lt;/strong&gt; (or &amp;ldquo;Glimpse Development&amp;rdquo;) Matrix channel. That channel is now invite-only and will eventually be deprecated, but channel members are still expected to comply with our &lt;a href=&#34;https://glimpse-editor.org/code-of-conduct/&#34;&gt;code of conduct&lt;/a&gt; and &lt;a href=&#34;https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right&#34;&gt;follow the rules&lt;/a&gt;.&lt;/p&gt;
 &lt;p&gt;&lt;a href=&#34;https://github.com/glimpse-editor/Glimpse/issues&#34;&gt;Github Issues&lt;/a&gt; are used to track bug reports, suggestions and questions from the wider community, and items we have agreed as a project need action. Action items are allocated to a milestone to give an indication of their priority and likely timeline, but these are always provisional until the work is done.&lt;/p&gt;
 &lt;p&gt;No decision is ever set in stone and can be revisited if new information comes to light or there is enough support within the project to do so. The governance team will generally only block the re-opening of an issue or delay a decision if the discussion is becoming too heated or obstructs the day-to-day running of the project. The governance team also reserves the right to end a discussion if, after giving an idea a fair hearing, there is clearly a lack of support within the Glimpse project in favor of it being worked on or developed any further.&lt;/p&gt;
 &lt;p&gt;Finally, the project may from time to time run polls on social media to canvas opinion for specific issues if there is support for doing so. They are always non-binding and only intended to facilitate the existing decision-making process.&lt;/p&gt;
 &lt;p&gt;&lt;a href=&#34;#contents&#34;&gt;Return to top&lt;/a&gt;&lt;/p&gt;
 &lt;h2 id=&#34;what-are-all-the-matrix-channels-for&#34;&gt;What are all the Matrix channels for?&lt;/h2&gt;
-&lt;p&gt;All of our channels are on matrix.org. You can get access to the invite-only channels by asking for it on the &amp;ldquo;Glimpse Community&amp;rdquo; channel.&lt;/p&gt;
+&lt;p&gt;We currently maintain two invite-only channels on matrix.org, and both have been bridged to matching channels on &lt;a href=&#34;https://discord.gg/hZhRceq&#34;&gt;our Discord server&lt;/a&gt;.&lt;/p&gt;
 &lt;ul&gt;
-&lt;li&gt;&lt;strong&gt;#glimpse&lt;/strong&gt;: &amp;ldquo;Glimpse Community&amp;rdquo; channel that anyone can join so long as they &lt;a href=&#34;https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right&#34;&gt;follow the rules&lt;/a&gt; and comply with our &lt;a href=&#34;https://glimpse-editor.org/code-of-conduct/&#34;&gt;code of conduct&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;strong&gt;#glimpse&lt;/strong&gt;: &amp;ldquo;Glimpse Development&amp;rdquo; channel that anyone can request to join, and all members must &lt;a href=&#34;https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right&#34;&gt;follow the rules&lt;/a&gt; and comply with our &lt;a href=&#34;https://glimpse-editor.org/code-of-conduct/&#34;&gt;code of conduct&lt;/a&gt;&lt;/li&gt;
 &lt;li&gt;&lt;strong&gt;#glimpse-offtopic&lt;/strong&gt;: Off-topic chatter between well-known members of our community in a safe, welcoming environment.&lt;/li&gt;
 &lt;/ul&gt;
-&lt;p&gt;There is also a separate &lt;a href=&#34;https://discord.gg/hZhRceq&#34;&gt;Discord server&lt;/a&gt; for our project moderation channels and the technical support queries. You can read their rules by following the links on the &lt;code&gt;#rules-and-info&lt;/code&gt; channel.&lt;/p&gt;
+&lt;p&gt;The &lt;a href=&#34;https://discord.gg/hZhRceq&#34;&gt;Discord server&lt;/a&gt; was created for our project moderation channels and Glimpse NX development. You can read the rules on that server by following the links on the &lt;code&gt;#rules-and-info&lt;/code&gt; channel.&lt;/p&gt;
+&lt;p&gt;We encourage new contributors to join Discord as that is where most project activity now happens. We eventually plan to deprecate our Matrix channels.&lt;/p&gt;
+&lt;p&gt;&lt;a href=&#34;#contents&#34;&gt;Return to top&lt;/a&gt;&lt;/p&gt;
+&lt;h2 id=&#34;why-are-you-deprecating-your-matrix-channels&#34;&gt;Why are you deprecating your Matrix channels?&lt;/h2&gt;
+&lt;p&gt;As you will have read elsewhere on this FAQs page, there are two parallel development streams in the Glimpse project:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;An open source fork of the GNU Image Manipulation Program 2.10.x called &amp;ldquo;Glimpse Image Editor&amp;rdquo;&lt;/li&gt;
+&lt;li&gt;A new open source image editing program for the GNOME desktop called &amp;ldquo;Glimpse NX&amp;rdquo;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;The eventual plan is to deprecate Glimpse Image Editor in favor of Glimpse NX. Matrix was the communication platform that was chosen by the fork&amp;rsquo;s contributors, and Discord was chosen by the Glimpse NX contributors.&lt;/p&gt;
+&lt;p&gt;Our Matrix channels are now both invite-only and have been bridged to our Discord server. We encourage new contributors join &lt;a href=&#34;https://discord.gg/hZhRceq&#34;&gt;our Discord server&lt;/a&gt; as that is where most project activity now happens.&lt;/p&gt;
+&lt;p&gt;For reference, these are the core values we follow when we select our project tools and collaboration platforms:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;We should aim to lower the barrier to entry for newcomers that have never contributed to an open source project before&lt;/li&gt;
+&lt;li&gt;We are open to trying any tools that our regular contributors suggest, and then using that experience to inform our decisions&lt;/li&gt;
+&lt;li&gt;We require comprehensive moderation tools that are not time-consuming to maintain, learn or use effectively&lt;/li&gt;
+&lt;li&gt;While open source solutions are preferred, our contributors&amp;rsquo; time and welfare are more important&lt;/li&gt;
+&lt;/ul&gt;
 &lt;p&gt;&lt;a href=&#34;#contents&#34;&gt;Return to top&lt;/a&gt;&lt;/p&gt;
 &lt;h2 id=&#34;how-do-i-stay-up-to-date-with-this-project&#34;&gt;How do I stay up-to-date with this project?&lt;/h2&gt;
 &lt;p&gt;You can follow us on &lt;a href=&#34;https://mastodon.art/@glimpse&#34;&gt;the fediverse&lt;/a&gt; and &lt;a href=&#34;https://twitter.com/glimpse_editor&#34;&gt;Twitter&lt;/a&gt;. This blog also has a full text &lt;a href=&#34;https://getglimpse.app/index.xml&#34;&gt;RSS feed&lt;/a&gt;. We also recently setup a &lt;a href=&#34;fb.me/glimpse.editor&#34;&gt;Facebook page&lt;/a&gt;.&lt;/p&gt;
 &lt;p&gt;Our &lt;a href=&#34;https://opencollective.com/glimpse&#34;&gt;Open Collective&lt;/a&gt; backers also get regular updates about the project.&lt;/p&gt;
-&lt;p&gt;Our Matrix and Discord channels are primarily intended for contributors and prospective contributors.&lt;/p&gt;
+&lt;p&gt;Our Matrix and Discord channels are primarily intended for existing and prospective contributors. If you only want to keep up with project news, we encourage you to follow our social media accounts and RSS feed instead.&lt;/p&gt;
 &lt;p&gt;&lt;a href=&#34;#contents&#34;&gt;Return to top&lt;/a&gt;&lt;/p&gt;
 &lt;h2 id=&#34;how-do-i-contribute-to-this-project&#34;&gt;How do I contribute to this project?&lt;/h2&gt;
 &lt;p&gt;All of our contribution links are available on our &lt;a href=&#34;https://glimpse-editor.org/contribute/&#34;&gt;Contribute&lt;/a&gt; page.&lt;/p&gt;
@@ -255,54 +316,12 @@
     </item>
     
     <item>
-      <title>Contribute</title>
-      <link>https://glimpse-editor.org/contribute/</link>
-      <pubDate>Sun, 01 Nov 2020 23:45:00 +0000</pubDate>
+      <title>Posts</title>
+      <link>https://glimpse-editor.org/posts/</link>
+      <pubDate>Sat, 21 Nov 2020 23:25:00 +0000</pubDate>
       
-      <guid>https://glimpse-editor.org/contribute/</guid>
-      <description>&lt;p&gt;Please note that we are developing Glimpse Image Editor in two parallel streams.&lt;/p&gt;
-&lt;p&gt;The &amp;ldquo;fork&amp;rdquo; stream is already providing a workable solution for people who dislike the &amp;ldquo;gimp&amp;rdquo; name or encounter barriers when they advocate the GNU Image Manipulation Program in schools, universities and workplaces. You can read more about our development priorities and our target userbase here: &lt;a href=&#34;https://github.com/glimpse-editor/Glimpse/wiki/Development-Priorities&#34;&gt;https://github.com/glimpse-editor/Glimpse/wiki/Development-Priorities&lt;/a&gt;&lt;/p&gt;
-&lt;p&gt;The &amp;ldquo;rewrite&amp;rdquo; stream (also known as &amp;ldquo;Glimpse NX&amp;rdquo;) aims to create a lightweight new interface for pre-existing GNU Image Manipulation Program libraries and frameworks. We will provide more details about that project in coming months.&lt;/p&gt;
-&lt;h2 id=&#34;code-bug-reports-etc-for-glimpse-image-editor&#34;&gt;Code, Bug Reports, etc for Glimpse Image Editor&lt;/h2&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;a href=&#34;https://github.com/glimpse-editor/Glimpse/issues&#34;&gt;Bug Reports&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href=&#34;https://github.com/glimpse-editor/Glimpse/milestones&#34;&gt;Development Road Map&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href=&#34;https://github.com/glimpse-editor/Glimpse&#34;&gt;Source Code&lt;/a&gt;&lt;/li&gt;
-&lt;/ul&gt;
-&lt;p&gt;You can also submit bug reports and feature requests &lt;a href=&#34;mailto:glimpse-editor@fire.fundersclub.com&#34;&gt;via email&lt;/a&gt;.&lt;/p&gt;
-&lt;h2 id=&#34;art-mockups-etc&#34;&gt;Art, mockups, etc.&lt;/h2&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;a href=&#34;https://github.com/glimpse-editor/branding&#34;&gt;Branding&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href=&#34;https://wiki.glimpse-editor.org/&#34;&gt;Wiki&lt;/a&gt;&lt;/li&gt;
-&lt;/ul&gt;
-&lt;h2 id=&#34;discussion-and-technical-support&#34;&gt;Discussion and Technical Support&lt;/h2&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;a href=&#34;https://matrix.to/#/#glimpse:matrix.org&#34;&gt;Matrix&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href=&#34;https://discord.gg/hZhRceq&#34;&gt;Discord&lt;/a&gt;&lt;/li&gt;
-&lt;/ul&gt;
-&lt;p&gt;&lt;strong&gt;Warning&lt;/strong&gt;: Before joining our public Matrix channel, we strongly encourage you to read &lt;a href=&#34;https://github.com/glimpse-editor/Glimpse/wiki/Good-Practices#membership-of-the-matrix-channel-is-a-privilege-not-a-right&#34;&gt;the rules you are expected to follow&lt;/a&gt;.&lt;/p&gt;
-&lt;h2 id=&#34;news&#34;&gt;News&lt;/h2&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;a href=&#34;https://fb.me/glimpse.editor&#34;&gt;Facebook&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href=&#34;https://mastodon.art/@glimpse&#34;&gt;Mastodon&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href=&#34;../posts/index.xml&#34;&gt;RSS&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href=&#34;https://twitter.com/glimpse_editor&#34;&gt;Twitter&lt;/a&gt;&lt;/li&gt;
-&lt;/ul&gt;
-&lt;h2 id=&#34;donate&#34;&gt;Donate&lt;/h2&gt;
-&lt;p&gt;To help cover our project&amp;rsquo;s costs and enable us to plan for future spending, please donate via these links:&lt;/p&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;a href=&#34;https://github.com/sponsors/glimpse-editor&#34;&gt;Github Sponsors&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href=&#34;https://opencollective.com/glimpse&#34;&gt;Open Collective&lt;/a&gt;&lt;/li&gt;
-&lt;/ul&gt;
-&lt;p&gt;If you can afford to do so we recommend donating to &lt;a href=&#34;https://www.gimp.org/donating/&#34;&gt;GNU Image Manipulation Program&lt;/a&gt;, the upstream project on which our fork relies. We periodically &lt;a href=&#34;https://opencollective.com/glimpse/expenses?tag=donation&#34;&gt;pass along a portion of our donations&lt;/a&gt; to them as our way of thanking them for the amazing work they do.&lt;/p&gt;
-&lt;h2 id=&#34;mediapress-contact&#34;&gt;Media/Press Contact&lt;/h2&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;a href=&#34;mailto:glimpse.editor@icloud.com&#34;&gt;Email&lt;/a&gt;&lt;/li&gt;
-&lt;/ul&gt;
-&lt;h2 id=&#34;community-supported-channels&#34;&gt;Community Supported Channels&lt;/h2&gt;
-&lt;p&gt;We welcome members of our community starting their own unofficial support forums and communication channels.
-Please note that we do not monitor or moderate those platforms, and cannot guarantee they are a safe and welcoming environment for everyone. &lt;strong&gt;If you choose to use them, you do so at your own risk.&lt;/strong&gt;&lt;/p&gt;
-</description>
+      <guid>https://glimpse-editor.org/posts/</guid>
+      <description></description>
     </item>
     
     <item>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -3,6 +3,16 @@
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   
   <url>
+    <loc>https://glimpse-editor.org/contribute/</loc>
+    <lastmod>2020-12-23T00:45:00+00:00</lastmod>
+  </url>
+  
+  <url>
+    <loc>https://glimpse-editor.org/about/</loc>
+    <lastmod>2020-12-23T00:30:00+00:00</lastmod>
+  </url>
+  
+  <url>
     <loc>https://glimpse-editor.org/</loc>
     <lastmod>2020-11-21T23:25:00+00:00</lastmod>
     <priority>0</priority>
@@ -16,16 +26,6 @@
   <url>
     <loc>https://glimpse-editor.org/posts/</loc>
     <lastmod>2020-11-21T23:25:00+00:00</lastmod>
-  </url>
-  
-  <url>
-    <loc>https://glimpse-editor.org/about/</loc>
-    <lastmod>2020-11-04T21:00:00+00:00</lastmod>
-  </url>
-  
-  <url>
-    <loc>https://glimpse-editor.org/contribute/</loc>
-    <lastmod>2020-11-01T23:45:00+00:00</lastmod>
   </url>
   
   <url>


### PR DESCRIPTION
This PR:

- Adds an FAQ explaining what's going on with the Matrix & Discord situation
- Updated references throughout the FAQs page accordingly
- Updated standardisation of "open source" so that we actually follow the FAQ answer about that!
- Updated contribute page with a note about Matrix channels being deprecated